### PR TITLE
ECR-1450: raise node and npm version to install peer deps automatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
         <npm.package.name>${application.name}</npm.package.name>
         <npm.project.version>${version.unique}</npm.project.version>
 
-        <node.version>v20.11.1</node.version>
-        <npm.version>7.24.2</npm.version>
+        <node.version>v20.18.1</node.version>
+        <npm.version>10.8.2</npm.version>
 
         <!-- 3rdparty -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
         <npm.package.name>${application.name}</npm.package.name>
         <npm.project.version>${version.unique}</npm.project.version>
 
-        <node.version>v16.15.0</node.version>
-        <npm.version>6.14.16</npm.version>
+        <node.version>v20.11.1</node.version>
+        <npm.version>7.24.2</npm.version>
 
         <!-- 3rdparty -->
 


### PR DESCRIPTION
Node and specifically Npm version has to be raised (npm>6) in order to install peer dependencies automatically in projects that use npm.
[Angular supported versions](https://angular.dev/reference/versions) require Node `^20.9.0`. Latest compatible node `v20.18.1` ships with npm `v10.8.2`