### PR TITLE
INTSRV-1032: Reduce javadoc log noise

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,6 +480,8 @@
                                 </sourcepath>
                                 <failOnWarnings>false</failOnWarnings>
                                 <failOnError>false</failOnError>
+                                <quiet>true</quiet>
+                                <doclint>all,-missing</doclint>
                                 <additionalOptions>-html5</additionalOptions>
                             </configuration>
                         </execution>


### PR DESCRIPTION
`<quiet>true</quiet>`:
Do not list each class for which generation was successfull (when there were no errors/warnings). Can lead to thousands of unnecessary log lines when a module has a lot of (or generated) classes.

`<doclint>all,-missing</doclint>`
Disable "missing" lint. Do not warn about missing javadoc on public methods/classes. Imo not having javadoc on a public method is fine. This linter just produces an very high amount of warnings for us and probably for others. Trivial methods should not need to be documented.

In addition to these changes, there is the problem that the plugin prints its output to both stdout and stderr, so everything appears twice in IntelliJs build output, but i have no fix for that.